### PR TITLE
Updated Styles and moved update all button

### DIFF
--- a/apps/plugins/views/plugins.jade
+++ b/apps/plugins/views/plugins.jade
@@ -26,13 +26,18 @@ html(lang="en")
 			});
 	body
 		#header
-			a.backlink
-				img(src="/core/icons/back.png")
-			h1  Plugins		
-			.loading.boxed
-				div
-					img(src="/core/css/img/ajax-loader.gif") 
-					p Loading modules...
+			div.pull-left
+				a.backlink
+					img(src="/core/icons/back.png")
+				h1  Plugins		
+				
+			div.loading.boxed.pull-left
+				img(src="/core/css/img/ajax-loader.gif") 
+				p Loading modules...
+
+			div.pull-right.boxed(data-bind="visible:upgradeAll().length > 0")
+				a.btn.upgrade.upgrade-all(data-bind="{click: upgradeAllPlugins.bind($data, upgradeAll() )}") Upgrade All
+		
 		#wrapper
 
 			div.message.boxed(data-bind="visible:message() != ''")
@@ -58,6 +63,5 @@ html(lang="en")
 						div.date(data-bind="text:'Added: '+date()")
 
 
-			div.boxed(data-bind="visible:upgradeAll().length > 0 ")
-				a.btn.upgrade(data-bind="{click: upgradeAllPlugins.bind($data, upgradeAll() )}") Upgrade All
+			
 			

--- a/public/plugins/css/style.css
+++ b/public/plugins/css/style.css
@@ -87,12 +87,14 @@ li.boxed.focused .btn,
 
 .version{display:none;}
 
-.loading div{
-	margin-top: -41px;
-	float: left;
-	margin-left: 250px;
+.loading{
+	margin: 10px 50px 0px 10px;
 	width:300px;
 }
 .loading img,
 .loading p{float:left; margin:0; font-weight:normal;}
 .loading p{margin:4px 0 0 10px;}
+
+.pull-left { float: left;}
+.pull-right {float:right;}
+.upgrade-all {margin:5px 0;}


### PR DESCRIPTION
Here is what is in this pull request:
I move the Upgrade All button into the title bar for easy access and modified some styling configure it. 
You can see it in attached screen shot. 

NOTES:
I like the tile styling to show each plugin however on my system it shows the buttons like what in the screen shot with the Upgrade Plugin on two lines.  I assume this wasn't by design and it was like this before I started messing with it.  I was going to let you fix it.  :)  Unless you want me to.

![plugins1](https://f.cloud.github.com/assets/602825/1442712/9e5f4ae4-41c5-11e3-83cd-27fdacd36fb0.jpg)
