### PR TITLE
Fixed oauth plugin src in jade template files

### DIFF
--- a/apps/settings/views/settings.jade
+++ b/apps/settings/views/settings.jade
@@ -1,7 +1,7 @@
 extends /layout
 
 block declarations
-    - additional_title     = lingua.settings; 
+    - additional_title     = lingua.settings;
     - include_validation   = true;
     - include_remote       = true;
 
@@ -9,7 +9,7 @@ block additional_css
     link(rel='stylesheet', href='/settings/css/style.css')
 
 block additional_scripts
-    script(src='/core/js/oauth.min.js')
+    script(src='/core/js/plugins/oauth.min.js')
     script.
         $(function() {
             $('body').mcjs();
@@ -55,11 +55,11 @@ block body
         #settings
             input.oauthKeyHidden(name="oauthKey" type="hidden")
             form#setup.validate-form(action='/submit',method='post')
-                h2 #{lingua.settings_header} 
+                h2 #{lingua.settings_header}
                 div#oauthContainer.mcjs-rc-controllable.row
                     span.info
                         span.quote &ldquo;
-                        span #{lingua.setting_oauth_explanation} 
+                        span #{lingua.setting_oauth_explanation}
                         span.quote &rdquo;
                     input#oauthKey.mcjs-rc-clickable(name="oauthKey" type="hidden", placeholder="OAuth.io Key", value="")
                     a.btn#oauth(href="#") #{lingua.setting_register_oauth}
@@ -71,7 +71,7 @@ block body
                 .row.wrap.mcjs-rc-controllable
                     a.btn.cachelink.mcjs-rc-clickable(data-cachelink="tvepisodes,tvshows") #{lingua.settings_clear_cache_tv}
                 .row.wrap.mcjs-rc-controllable
-                    a.btn.cachelink.mcjs-rc-clickable(data-cachelink="devices") #{lingua.settings_clear_cache_device} 
+                    a.btn.cachelink.mcjs-rc-clickable(data-cachelink="devices") #{lingua.settings_clear_cache_device}
                 .row.mcjs-rc-controllable
                     label(for="moviepath") #{lingua.setting_movielocation}
                     input#moviepath.mcjs-rc-clickable(name="moviepath",type="text",placeholder="#{lingua.settings_placeholder_path}", value= movielocation,data-rule-path="true",	data-msg-path="Specify a valid path. <br/>Please end with a slash and use forward slashes.")
@@ -117,7 +117,7 @@ block body
                         table
                             thead
                                 tr
-                                    th #{lingua.settings_device_id}: 
+                                    th #{lingua.settings_device_id}:
                                     th #{lingua.settings_device_seen}:
                                     th #{lingua.settings_device_allowed}:
                                     th #{lingua.settings_device_parental}:

--- a/apps/youtube/views/youtube.jade
+++ b/apps/youtube/views/youtube.jade
@@ -17,7 +17,7 @@ html(lang="en", ng-app="youtubeApp")
 		script(src="/core/js/socket.io.min.js")
 		script(src="/core/js/jquery.mcjs.core.js")
 		// OAuth.io
-		script(src='/core/js/oauth.min.js')
+		script(src='/core/js/plugins/oauth.min.js')
 		// Custom scripts
 		script(src='/core/js/plugins/iso8601.min.js')
 		script(src="/core/js/plugins/video.js")
@@ -27,7 +27,7 @@ html(lang="en", ng-app="youtubeApp")
 		script(src="/youtube/js/directives.js")
 		script(src="/youtube/js/services.js")
 		title Youtube
-		
+
 	body
 		#wrapper
 			ng-view

--- a/views/setup.jade
+++ b/views/setup.jade
@@ -8,7 +8,7 @@ block additional_css
 	link(rel='stylesheet', href='/settings/css/style.css')
 
 block additional_scripts
-	script(src='/core/js/oauth.min.js')
+	script(src='/core/js/plugins/oauth.min.js')
 	script(src="/settings/js/jquery.mcjs.settings.js")
 	script.
 		$(function() {


### PR DESCRIPTION
Hi,

I've tried to install MediaCenterJS both from Github and NPM and both are broken in term of OAuth capabilities. It seems it dates from 18 days ago with [this commit](https://github.com/jansmolders86/mediacenterjs/commit/c0402075cc7f79f42b3e63532f20f1d60350900d) when you changed the directory structure, you did not change oauth path at the same time, which end up producing a `404` and the inhabitlity to connect to a Google account to use the Youtube App.

Hope this fixes it (it did for my local install). I haven't had a deeper look into it, there may be other path that needs some fixing that I didn't spot.

Thanks for making this app, it looks really promising.

---

One question that is not related to this PR, on the website the screenshot shows integration with Google Music, is it an official and already released plugin ? It wasn't proposed on the plugin page.

One more thing, when I tried to install the Google Map plugin it failed, in the console it showed a 404 when trying to get the tagged archive from github, but I may be better of reporting this on the Google Map plugin repository.
