### PR TITLE
Quote fileLocation for metadata fetcher

### DIFF
--- a/lib/utils/metadata-fetcher.js
+++ b/lib/utils/metadata-fetcher.js
@@ -8,10 +8,10 @@ var path = require('path');
 
 exports.fetch = function(req, res, dataType, callback) {
     var appDir = path.dirname(require.main.filename)
-        , fileLocation = 'node '+appDir+'/lib/utils/metadata/'+dataType+'-metadata.js'
+        , fileLocation = path.join(__dirname, 'metadata', dataType+'-metadata.js')
 		, dataType = dataType
         , exec = require('child_process').exec
-        , child = exec(fileLocation, { maxBuffer: 9000*1024 }, function(err, stdout, stderror) {
+        , child = exec('node "' + fileLocation + '"', { maxBuffer: 9000*1024 }, function(err, stdout, stderror) {
             if (err) {
                 console.log('Metadata fetcher error: ',err) ;
             }


### PR DESCRIPTION
The fileLocation needs to be quotes because otherwise, filesystems will
fail if paths have spaces in them. Quoting is also compatible with
*nixes and windows.
In addition, get file path via path.join and __dirname.

This fixes #91
