### PR TITLE
Making mediaserverjs work from a dedicated server

### DIFF
--- a/public/movies/js/app.js
+++ b/public/movies/js/app.js
@@ -19,7 +19,7 @@
 
 var movieApp = angular.module('movieApp', []);
 
-movieApp.controller('movieCtrl', function($scope, $http,$document,$window, socket) {
+movieApp.controller('movieCtrl', function($scope, $http, $document, $window, socket) {
     $scope.focused = 0;
     $http.get('/movies/loadItems').success(function(data) {
         $scope.movies = data;
@@ -54,7 +54,7 @@ movieApp.directive("scroll", function ($document,$window) {
 });
 
 movieApp.factory('socket', function ($rootScope) {
-    var socket = io.connect('http://127.0.0.1:3001');
+    var socket = io.connect(document.domain + ':3001');
     socket.on('connect', function(data){
         socket.emit('screen');
     });

--- a/public/music/js/app.js
+++ b/public/music/js/app.js
@@ -122,7 +122,7 @@
 
 
     musicApp.factory('socket', function ($rootScope) {
-        var socket = io.connect('http://127.0.0.1:3001');
+        var socket = io.connect(document.domain + ':3001');
         socket.on('connect', function(data){
             socket.emit('screen');
         });

--- a/public/tv/js/app.js
+++ b/public/tv/js/app.js
@@ -37,7 +37,7 @@ tvApp.controller('tvCtrl', function($scope, $http, socket, player){
 });
 
 tvApp.factory('socket', function ($rootScope) {
-    var socket = io.connect('http://127.0.0.1:3001');
+    var socket = io.connect(document.domain + ':3001');
     socket.on('connect', function(data){
         socket.emit('screen');
     });


### PR DESCRIPTION
Having 127.0.0.1 meant connecting to mediaserverjs from another machine
would break it.  Document.domain gives more flexibility.
