### PR TITLE
Moved to fs-extra

### DIFF
--- a/apps/music/metadata-processor.js
+++ b/apps/music/metadata-processor.js
@@ -1,6 +1,6 @@
 var LastfmAPI = require('lastfmapi')
 , mm = require('musicmetadata')
-, fs = require('fs.extra')
+, fs = require('fs-extra')
 , logger = require('winston');
 
 exports.valid_filetypes = /(m4a|mp3)$/gi;

--- a/apps/plugins/index.js
+++ b/apps/plugins/index.js
@@ -1,6 +1,6 @@
 /*
 	MediaCenterJS - A NodeJS based mediacenter solution
-	
+
     Copyright (C) 2013 - Jan Smolders
 
     This program is free software: you can redistribute it and/or modify
@@ -19,25 +19,25 @@
 exports.engine = 'jade';
 
 /* Modules */
-var fs = require('fs')
+var fs = require('fs-extra')
 , ini = require('ini')
 , config = ini.parse(fs.readFileSync('./configuration/config.ini', 'utf-8'))
 , functions = require('./plugins-functions');
- 
+
 // Choose your render engine. The default choice is JADE:  http://jade-lang.com/
 exports.engine = 'jade';
 
-exports.index = function(req, res, next){	
+exports.index = function(req, res, next){
 	res.render('plugins',{
 		selectedTheme: config.theme
 	});
 };
 
-exports.get = function(req, res, next){	
+exports.get = function(req, res, next){
 	var infoRequest = req.params.id
 	, optionalParam = req.params.optionalParam
 	, action = req.params.action;
-	
+
 	var handled = false;
 
 	if (optionalParam === undefined){
@@ -49,17 +49,17 @@ exports.get = function(req, res, next){
 			case('reloadServer'):
 				functions.reloadServer(req,res);
 				handled = true;
-			break;		
-		}	
+			break;
+		}
 	}
 
-	
+
 	if(!action){
 		switch(optionalParam) {
 			case('uninstall'):
 				functions.pluginManager(req, res, infoRequest, 'remove');
 				handled = true;
-			break;	
+			break;
 			case('install'):
 				functions.pluginManager(req,res, infoRequest, 'install');
 				handled = true;
@@ -67,9 +67,9 @@ exports.get = function(req, res, next){
 			case('upgrade'):
 				functions.pluginManager(req,res, infoRequest, 'install');  //for some reason update isnt working
 				handled = true;
-			break;	
+			break;
 		}
-	}	
+	}
 	if (!handled) {
 		next();
 	}

--- a/apps/plugins/plugins-functions.js
+++ b/apps/plugins/plugins-functions.js
@@ -17,7 +17,7 @@
 */
 var express = require('express')
     , app = express()
-    , fs = require('fs')
+    , fs = require('fs-extra')
     , ini = require('ini')
     , semver = require('semver')
     , config = ini.parse(fs.readFileSync('./configuration/config.ini', 'utf-8'))
@@ -200,4 +200,3 @@ exports.reloadServer = function(req, res){
         res.json('');
     });
 }
-

--- a/apps/remote/index.js
+++ b/apps/remote/index.js
@@ -1,6 +1,6 @@
 /*
 	MediaCenterJS - A NodeJS based mediacenter solution
-	
+
     Copyright (C) 2013 - Jan Smolders
 
     This program is free software: you can redistribute it and/or modify
@@ -21,14 +21,14 @@ exports.engine = 'jade';
 
 var express = require('express')
 , app = express()
-, fs = require('fs')
+, fs = require('fs-extra')
 , ini = require('ini')
 , os = require('os')
 , config = ini.parse(fs.readFileSync('./configuration/config.ini', 'utf-8'))
 , DeviceInfo = require('../../lib/utils/device-utils')
 , config = ini.parse(fs.readFileSync('./configuration/config.ini', 'utf-8'));
 
-exports.index = function(req, res, next){	
+exports.index = function(req, res, next){
 
     DeviceInfo.storeDeviceInfo(req);
 

--- a/apps/settings/index.js
+++ b/apps/settings/index.js
@@ -20,7 +20,7 @@ exports.engine = 'jade';
 
 var express = require('express')
 , app = express()
-, fs = require('fs')
+, fs = require('fs-extra')
 , ini = require('ini')
 , http = require('http')
 , DeviceInfo = require('../../lib/utils/device-utils')
@@ -142,4 +142,3 @@ function loadCustomSettings(callback){
     });
     callback(plugSettings);
 }
-

--- a/apps/youtube/index.js
+++ b/apps/youtube/index.js
@@ -23,7 +23,7 @@ exports.engine = 'jade';
 // Render the indexpage
 var Youtube = require('youtube-api')
 , iso8601 = require('./iso8601.js')
-, fs = require('fs')
+, fs = require('fs-extra')
 , ini = require('ini')
 , jade = require('jade')
 , configuration_handler = require('../../lib/handlers/configuration-handler')

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@
 
 var express = require('express')
     , app = express()
-    , fs = require ('fs')
+    , fs = require ('fs-extra')
     , util = require('util')
     , dateFormat = require('dateformat')
     , lingua = require('lingua')

--- a/lib/handlers/app-cache-handler.js
+++ b/lib/handlers/app-cache-handler.js
@@ -16,7 +16,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 /* Global imports */
-var fs = require('fs.extra'),
+var fs = require('fs-extra'),
     path = require('path'),
     url = require('url'),
     configuration_handler = require('./configuration-handler'),
@@ -95,4 +95,3 @@ exports.clearCache = function(app, callback) {
 		callback(err);
 	});
 };
-

--- a/lib/handlers/configuration-handler.js
+++ b/lib/handlers/configuration-handler.js
@@ -16,7 +16,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 /* Global imports */
-var fs = require('fs'),
+var fs = require('fs-extra'),
     _ = require('underscore');
 
 /* Constants */

--- a/lib/handlers/music-playback.js
+++ b/lib/handlers/music-playback.js
@@ -1,6 +1,6 @@
 /*
   MediaCenterJS - A NodeJS based mediacenter solution
-  
+
     Copyright (C) 2014 - Jan Smolders
 
     This program is free software: you can redistribute it and/or modify
@@ -17,7 +17,7 @@
 */
 /* Global imports */
 var colors = require('colors'),
-  fs = require('fs.extra'),
+  fs = require('fs-extra'),
   config = require('../../lib/handlers/configuration-handler').getConfiguration();
 
 /* Public Methods */

--- a/lib/handlers/video-playback.js
+++ b/lib/handlers/video-playback.js
@@ -17,12 +17,13 @@
 */
 
 var colors = require('colors')
-, fs = require('fs.extra')
+, fs = require('fs-extra')
 , path = require('path')
 , config = require('../../lib/handlers/configuration-handler').getConfiguration()
 , logger = require('winston')
 , transcoder = require('../transcoding')
-, fileUtils = require('../utils/file-utils');
+, fileUtils = require('../utils/file-utils')
+;
 
 /**
  * Starts video streaming for the specified file.

--- a/lib/routing/routing.js
+++ b/lib/routing/routing.js
@@ -18,7 +18,7 @@
 
 var express = require('express')
   , static = require('serve-static')
-  , fs = require('fs')
+  , fs = require('fs-extra')
   , colors = require('colors')
   , ini = require('ini')
   , path = require('path')

--- a/lib/transcoding/index.js
+++ b/lib/transcoding/index.js
@@ -1,5 +1,5 @@
 var os = require('os');
-var fs = require('fs.extra');
+var fs = require('fs-extra');
 var ffmpeg = require('fluent-ffmpeg');
 var logger = require('winston');
 var _ = require('underscore');

--- a/lib/utils/ajax-utils.js
+++ b/lib/utils/ajax-utils.js
@@ -45,7 +45,7 @@ exports.xhrCall = function (url, callback) {
  @param callback        The Callback (returns the contents as string)
  */
 exports.writeToFile = function (writePath, dataToWrite, callback){
-    var fs = require('fs');
+    var fs = require('fs-extra');
 
     fs.writeFile(writePath, dataToWrite, function(writeErr) {
         if (!writeErr) {

--- a/lib/utils/apps.js
+++ b/lib/utils/apps.js
@@ -15,7 +15,7 @@
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-var fs = require('fs')
+var fs = require('fs-extra')
     , configuration_handler = require('../handlers/configuration-handler');
 var config = configuration_handler.initializeConfiguration();
 var path = require('path');
@@ -30,7 +30,7 @@ exports.getApps = function () {
             || (name === 'tv' && config.tvpath === "")) {
             return;
         }
-        
+
         addApp('./public/' + name, name, apps);
     });
 

--- a/lib/utils/file-utils.js
+++ b/lib/utils/file-utils.js
@@ -26,7 +26,7 @@ logger = require('winston');
  @param callback    The Callback function
  */
 exports.getLocalFiles = function (dir, suffix, callback) {
-    var fs = require('fs'),
+    var fs = require('fs-extra'),
         walk = require('walk'),
         path = require('path');
 

--- a/lib/utils/logging.js
+++ b/lib/utils/logging.js
@@ -15,7 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-var fs  = require('fs.extra')
+var fs  = require('fs-extra')
 var logger = require('winston');
 
 var path = require('path');

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "serve-favicon": "^2.2.0",
     "errorhandler": "^1.3.2",
     "fluent-ffmpeg": "^1.7.2",
-    "fs.extra": "^1.3.2",
+    "fs-extra": "^0.16.3",
     "ini": "^1.3.2",
     "jade": "^1.7.0",
     "lastfmapi": "^0.0.5",

--- a/server.js
+++ b/server.js
@@ -43,7 +43,7 @@ var child_process = require('child_process')
 
 function installUpdate(output, dir){
     logger.info('Installing update...');
-    var fsExtra = require("fs.extra");
+    var fsExtra = require("fs-extra");
     fsExtra.copy('./install/mediacenterjs-master', './', function (err) {
         if (err) {
             logger.error('Error', err);

--- a/server.js
+++ b/server.js
@@ -24,7 +24,7 @@
 
 
 var child_process = require('child_process')
-    , fs = require("fs")
+    , fs = require("fs-extra")
     , sys = require("sys")
     , logger = require('winston');
 
@@ -43,8 +43,7 @@ var child_process = require('child_process')
 
 function installUpdate(output, dir){
     logger.info('Installing update...');
-    var fsExtra = require("fs-extra");
-    fsExtra.copy('./install/mediacenterjs-master', './', function (err) {
+    fs.copy('./install/mediacenterjs-master', './', function (err) {
         if (err) {
             logger.error('Error', err);
         } else {


### PR DESCRIPTION
Resolved #184 

Since fs.extra was outdated and a crash was happening, I've moved the entire project to the actively maintain [fs-extra](https://github.com/jprichardson/node-fs-extra) library. For coherence since the fs-extra library extends the standard fs, all has been substituted with fs-extra.