### PR TITLE
Subtitles with . and/or language code in the filename are detected

### DIFF
--- a/lib/handlers/video-playback.js
+++ b/lib/handlers/video-playback.js
@@ -41,21 +41,18 @@ exports.startPlayback = function(response, platform, mediaObject, type) {
       return response.status(404).send();
     }
 
-    var fileUrl = mediaObject.filePath;
-    var fileName = path.basename(mediaObject.filePath);
+    var fileUrl      = mediaObject.filePath;
+    var fileDir      = path.dirname(fileUrl);
+    var fileName     = path.basename(fileUrl);
+    var fileExt      = path.extname(fileUrl);
+    var fileBaseName = path.basename(fileUrl, fileExt);
 
-    var subtitleUrl = fileUrl;
-    subtitleUrl     = subtitleUrl.split(".");
-    subtitleUrl     = subtitleUrl[0]+".srt";
-
-    var subtitleTitle   = fileName;
-    subtitleTitle       = subtitleTitle.split(".");
-    subtitleTitle       = subtitleTitle[0]+".srt";
-
+    var subtitleTitle = fileBaseName + '.srt';
+    
     var filetype = fileName.match(/[^.]+$/);
     filetype = filetype ? filetype.toString() : '';
 
-    var normalizedFilename = fileName.replace(/\.[^.]*$/, '.mp4').replace(/ /g, '-');
+    var normalizedFilename = fileBaseName.replace(/ /g, '-') + '.mp4';
     var dataDir = './public/data/' + type;
     var outputPath = path.join(dataDir, normalizedFilename);
     var hasSub = false;
@@ -64,11 +61,18 @@ exports.startPlayback = function(response, platform, mediaObject, type) {
     fs.mkdirpSync(dataDir);
 
     // Check if subtitles exist and copy them to data folder
-    if (isThere.sync(subtitleUrl)) {
-        var subOutput = path.join(dataDir, subtitleTitle);
-        fs.copySync(subtitleUrl, subOutput);
-        hasSub = true;
-    }
+    var files = fs.readdirSync(fileDir);
+    files.forEach(function(file) {
+        // search for "my_movie_file.srt" or "my_movie_file.it.srt" (XBMC downloads subtitles with the language code)
+        if (file.indexOf(fileBaseName) === 0 && file.match(/\.srt$/i)) {
+            var subtitleUrl = path.join(fileDir, file);
+            var subOutput = path.join(dataDir, subtitleTitle);
+            fs.copySync(subtitleUrl, subOutput);
+            hasSub = true;
+            // break the loop
+            return false;
+        }
+    });
 
     checkProgression(mediaObject.id, type, function(data) {
         if(data.transcodingstatus === 'pending' || data.transcodingstatus === undefined) {


### PR DESCRIPTION
So far subtitles files named like `my.movie.file.srt` were not found because the `subtitleUrl.split('.')[0]` part would search for `my.srt`.
Using `path` features the file selection is safer.
Also, subtitle files with language code (or other strings) in it are detected (XBMC by default downloads subtitles with pattern `movie file name.{langCode}.srt`)