### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "semver": ">=2.0.0",
         "sequelize": "^3.0.0",
         "socket.io": "^0.9.16",
-        "sqlite3": "3.0.5",
+        "sqlite3": "~3.1.4",
         "to-title-case": "^0.1.5",
         "umzug": "^1.6.0",
         "underscore": "^1.7.0",


### PR DESCRIPTION
update sqlite3 to latest, with `~` for matching...

Should probably run an install with the update, then bump all the versions to `~#.#.#` instead of `^`...

Closes #224 