### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Feel free to contribute by translating.
 * [Jonathan Bailey](https://github.com/Jon889) for his hudge code contributions and database abstraction layer
 * [Matthew Marino](https://github.com/Karnith) for his FFMPEG expertise
 
-###Special thanks to these contributors:###
+### Special thanks to these contributors: ###
 
 
 * [Sylvain](https://github.com/flyinva) for his French translation


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
