### PR TITLE
#243 Serial processing of audio tracks, fix the progress counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Supported file formats:
 ==================
 Video: AVI/MOV/WMV/MP4/MKV/MPEG
 
-Audio: MP3/M4a 
+Audio: M4A/MP2/MP3/MP4/FLAC/WMA/ASF/OGG/OPUS/WV/WAV
 
 Known issues:
 =================

--- a/lib/media-handler.js
+++ b/lib/media-handler.js
@@ -38,6 +38,23 @@ MediaHandler.prototype.load = function(findOptions, callback, dontFetchMetadata)
   });
 }
 
+MediaHandler.prototype._fetchMetadata = function(total, files, callback) {
+	var self = this;
+	var file = files.shift();
+	if(file) {
+		self.metadataProcessor.processFile(file, function() {
+			// Process next file
+			self._fetchMetadata(total, files, callback);
+			// Report progress
+			var percentage = 100 - (files.length / total) * 100;
+			console.log(`Reading audio file progress: ${percentage}`);
+			io.sockets.emit('progress', { msg: percentage });
+		});
+	} else {
+		callback(); // Callback when all Files where processed
+	}
+}
+
 MediaHandler.prototype.fetchMetadata = function(callback) {
   var self = this;
   fileUtils.getLocalFiles(this.media_dir, self.metadataProcessor.valid_filetypes, function(err, files) {
@@ -46,20 +63,8 @@ MediaHandler.prototype.fetchMetadata = function(callback) {
       callback(err);
     }
 
-    var currentFileIndex = 1;
-    _.each(files, function(file) {
-      self.metadataProcessor.processFile(file, function() {
-        // Callback when all Files where processed
-        if (currentFileIndex == files.length) {
-          callback();
-        }
-
-        // Report progress
-        currentFileIndex++;
-        var percentage = parseInt((currentFileIndex / files.length) * 100, 10);
-        io.sockets.emit('progress', { msg: percentage });
-      });
-    });
+    // Process file serial
+    self._fetchMetadata(files.length, files, callback);
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "lingua": "^0.4.0",
         "method-override": "^2.3.1",
         "moviedb": "^0.2.0",
-        "musicmetadata": "^0.4.6",
+        "music-metadata": "^2.4.1",
         "node-ffprobe": "^1.2.2",
         "node-schedule": "^0.1.13",
         "npm": "^3.5.0",


### PR DESCRIPTION
* #244: Ensure callbacks are called in media-handler
* #243: Serial processing of audio tracks, fix the progress counter
* Replace abandoned dependency musicmetadata with [music-metadata](https://github.com/Borewit/music-metadata)
* Add additional audio formats: M4A, MP2, MP4, FLAC, WMA, ASF, OGG, OPUS, WV, WAV

These are some improvements, but there is yet more work todo.
